### PR TITLE
Prevent database is locked errors

### DIFF
--- a/httpd.js
+++ b/httpd.js
@@ -7,7 +7,7 @@ var moment = require('moment');
 var express = require("express");
 
 var app = express();
-var db = new sqlite3.Database(DB_FILE);
+var db = new sqlite3.Database(DB_FILE, sqlite3.OPEN_READONLY));
 
 var isValidChart = function(s) {
     return /^(net_in|net_out|block_in|block_out|mem)$/.test(s);

--- a/stats.js
+++ b/stats.js
@@ -120,6 +120,8 @@ var main = function() {
     writeStats(containers);
 };
 
+db.run("PRAGMA journal_mode=WAL");
+
 db.run("CREATE TABLE IF NOT EXISTS containers ( " +
     "id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, " +
     "name TEXT NOT NULL)");


### PR DESCRIPTION
Hi,
Thanks for this simple but effective frontend to see docker container statistics.
I was getting some errors on httpd.js, it was crashing with:

```
/opt/docker-stats/httpd.js:48
        for (var i=0; i<rows.length; i++) {
                            ^
TypeError: Cannot read property 'length' of undefined
```

After some checking I found an underlying error:

```
Error: SQLITE_BUSY: database is locked
    at Error (native)
```

The error can be prevented: Since there are only SELECT statements, the database can be opened as read-only, as this commit suggests.

Feel free to merge