### PR TITLE
Fix Performance issue in frontend

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -89,6 +89,15 @@ var writeContainerStats = function(cid, container, now) {
     });
 };
 
+var clearOldContainerStats = function() {
+    var stm = db.prepare("DELETE FROM stats WHERE ts < ?");
+    var now = moment();
+    now.subtract(1, 'months');
+    var time = now.format('YYYY-MM-DD HH:mm:ss');
+    stm.run(time)
+    stm.finalize();
+}
+
 var writeStats = function(containers) {
     var now = moment().format('YYYY-MM-DD HH:mm:ss');
     for (var id in containers) {
@@ -101,6 +110,7 @@ var main = function() {
     var containers = getContainers();
     writeStats(containers);
     setTimeout(main, INTERVAL*1000);
+    setInterval(clearOldContainerStats, 24 * 60 * 60 * 1000); // Daily removal of old stats
 };
 
 db.run("PRAGMA journal_mode=WAL");


### PR DESCRIPTION
When setting the filter to 'week' or 'month' I noticed that there is a lot of data involved when rendering the graphs. This made my browser use several GB of GPU memory and the tab sometimes even crashed entirely.

This PR introduces the following:

- Reduce number of data entries for each graph to a max value of 1000. This is done in a way that preserves peeks and only gets rid of smaller values.
- Clear database entries that are older than one month - just for good measure