### PR TITLE
Update Alpine to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.19
 ARG BUILD_DATE
 ARG VCS_REF
 LABEL org.label-schema.build-date=$BUILD_DATE \


### PR DESCRIPTION
This PR updates the alpine base image to 3.19, the latest version available currently.

Testing:
- Made sure image still functions as normal